### PR TITLE
demo of working webpack, with live reload triggered by nodemon when u…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.log
 /public/uploads
 /public/apos-minified
 /data/temp/uploadfs
+/modules/asset/ui/public/site.js
 node_modules
 # This folder is created on the fly and contains symlinks updated at startup (we'll come up with a Windows solution that actually copies things)
 /public/modules

--- a/app.js
+++ b/app.js
@@ -44,6 +44,14 @@ require('apostrophe')({
     'recipe': {},
     'recipe-page': {},
     'recipe-widget': {},
-    'asset': {}
+    // A home for our own assets
+    'asset': {},
+    // Manages apostrophe's overall asset pipeline
+    '@apostrophecms/asset': {
+      // When not in production, refresh the page on restart
+      options: {
+        refreshOnRestart: true
+      }
+    }
   }
 });

--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ require('apostrophe')({
     },
     'recipe': {},
     'recipe-page': {},
-    'recipe-widget': {}
+    'recipe-widget': {},
+    'asset': {}
   }
 });

--- a/modules/asset/index.js
+++ b/modules/asset/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "apostrophe-build": "node app @apostrophecms/asset:build",
     "start": "node app",
     "dev": "nodemon -x \"npm run build && nodemon app.js\"",
-    "dev:back": "node-dev app.js",
-    "dev:front": "nodemon -x \"npm run build\"",
     "storybook": "node app @apostrophecms/storybook:run",
     "storybook-build": "node app @apostrophecms/storybook:build ./storybook-static",
     "storybook-deploy": "node app @apostrophecms/storybook:deploy",

--- a/package.json
+++ b/package.json
@@ -4,23 +4,27 @@
   "description": "Apostrophe 3 Demo Site",
   "main": "app.js",
   "scripts": {
-    "build": "node app @apostrophecms/asset:build",
-    "analyze-bundle": "APOS_BUNDLE_ANALYZER=1 node app @apostrophecms/asset:build",
+    "build": "webpack && npm run apostrophe-build",
+    "apostrophe-build": "node app @apostrophecms/asset:build",
+    "start": "node app",
     "dev": "nodemon -x \"npm run build && nodemon app.js\"",
     "dev:back": "node-dev app.js",
     "dev:front": "nodemon -x \"npm run build\"",
-    "start": "node app.js",
     "storybook": "node app @apostrophecms/storybook:run",
     "storybook-build": "node app @apostrophecms/storybook:build ./storybook-static",
     "storybook-deploy": "node app @apostrophecms/storybook:deploy",
-    "staging-deploy": "echo \"ℹ️  Clearing module links and installed modules to deploy.\" && rm package-lock.json && rm -r node_modules && npm i && sc-deploy staging"
+    "staging-deploy": "echo \"ℹ️  Clearing module links and installed modules to deploy.\" && rm package-lock.json && rm -r node_modules && npm i && sc-deploy staging",
+    "analyze-bundle": "APOS_BUNDLE_ANALYZER=1 node app @apostrophecms/asset:build"
   },
   "repository": {
     "type": "git",
     "url": ""
   },
   "dependencies": {
-    "apostrophe": "apostrophecms/apostrophe#3.0"
+    "apostrophe": "apostrophecms/apostrophe#3.0",
+    "bootstrap": "^4.5.2",
+    "webpack": "^4.44.2",
+    "webpack-cli": "^3.3.12"
   },
   "author": "Apostrophe Technologies, Inc",
   "license": "MIT",
@@ -29,6 +33,7 @@
     "watch": [
       "./app.js",
       "./modules/**/*",
+      "./src/**/*",
       "./node_modules/apostrophe/modules/@apostrophecms/**/*"
     ],
     "ignoreRoot": [
@@ -42,12 +47,20 @@
       "public/uploads",
       "public/apos-minified/*.js",
       "public/css/master-*.less",
+      "modules/asset/ui/public/site.js",
       "data"
     ],
     "ext": "json, js, html, scss, vue"
   },
   "devDependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "babel-loader": "^8.1.0",
+    "css-loader": "^4.3.0",
     "node-dev": "^5.2.0",
-    "nodemon": "^2.0.4"
+    "nodemon": "^2.0.4",
+    "sass": "^1.26.11",
+    "sass-loader": "^10.0.2",
+    "style-loader": "^1.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import './index.scss';
+
+console.log('look at me, I am project level js');

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,0 +1,3 @@
+body {
+  background-color: purple;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,4 @@
-body {
-  background-color: purple;
-}
+// Handy example for testing refreshOnRestart
+// .apos-editor-context {
+//   background-color: red !important;
+// }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
               presets: ['@babel/preset-env']
             }
           }
-          // 'eslint-loader'
         ]
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,38 @@
+const path = require('path');
+
 module.exports = {
-  entry: './src/index.js'
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(
+      __dirname, 'modules/asset/ui/public'
+    ),
+    filename: 'site.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env']
+            }
+          }
+          // 'eslint-loader'
+        ]
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader'
+          }
+        ]
+      }
+    ]
+  }
 };


### PR DESCRIPTION
…sed with the appropriate branch of a3. Webpack build includes modern js via babel and sass support, with the sass index file imported by the js index file to avoid the need for a separate link tag. The output of the project level build is pushed as a public asset to the apostrophe build for proper minification etc.

With sass support, it should be possible to import bootstrap the nice way too. I believe we have to add a postcss prefixer thing as well for that, but this incremental step shows we can go down that road.