### PR TITLE
we do not need extend when we are configuring an existing core module…

### DIFF
--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extend: '@apostrophecms/page-type',
   options: {
     label: 'Home Page',
     pluralLabel: 'Home Pages'


### PR DESCRIPTION
…, and using it would bypass the core module code. In this case that's not a huge deal, but it creates a potential impression of a bug in module inheritance.