### PR TITLE
just set width to 100% on the video player and any iframe within it, …

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -5,9 +5,6 @@
 
 .demo-video {
   width: 100%;
-  iframe {
-    width: 100%;
-  }
 }
 
 .demo-image {

--- a/src/index.scss
+++ b/src/index.scss
@@ -4,17 +4,10 @@
 @import '_sidenav';
 
 .demo-video {
-  position: relative;
-  padding-bottom: 56.25%;
-  height: 0;
-}
-
-.demo-video iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
+  iframe {
+    width: 100%;
+  }
 }
 
 .demo-image {


### PR DESCRIPTION
…then the height calculation magic in the apostrophe video player can do its job and it works right both on mobile and desktop. I will check if boilerplate needs this too. If you do not have it you get the video at its suggested width which is usually much too small