### PR TITLE
Switches back to the 3.0 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "url": ""
   },
   "dependencies": {
-    "apostrophe": "apostrophecms/apostrophe#demo",
-    "bootstrap": "^4.5.2",
+    "apostrophe": "apostrophecms/apostrophe#3.0",
     "extract-css-chunks-webpack-plugin": "^4.8.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12"


### PR DESCRIPTION
I don't think we still need the demo branch, right? This was throwing a wrench into deploying since we're not regularly updating that.