### PR TITLE
Clears up npm link requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 ## Get started
 
-1. Install dependencies: `npm install`
-2. At the moment, you must have a local copy of `apostrophe` using the `3.0` branch and link that to this project. In whatever local directory you keep your dev work in, run:
-   1. `git clone git@github.com:apostrophecms/apostrophe.git && cd apostrophe`
-   2. `git fetch && git checkout 3.0` to get on the correct branch.
-   3. `npm link` to set Apostrophe up for linking in the project.
-3. Back in the `a3-demo` project, link up Apostrophe: `npm link apostrophe`.
+Install dependencies with `npm install`.
+
+If you are doing local development on Apostrophe core and want to use the demo for that you will need to link it to this project. In whatever local directory you keep your dev work in, run:
+1. `git clone git@github.com:apostrophecms/apostrophe.git && cd apostrophe`
+2. `git fetch && git checkout 3.0` to get on the correct starting branch.
+3. Start a new feature branch for your work. The core team convention has been to start 3.0 branch names with `3/`.
+4. `npm link` to set Apostrophe up for linking in the project.
+5. Back in the `a3-demo` project, link up Apostrophe: `npm link apostrophe`.
 
 ## Running the project
 


### PR DESCRIPTION
We got some confusion about the necessity to link. Core 3.0 in the dependencies, so you don't actually need to link.