### PR TITLE
Adds sizes attribute for image widget in two-col

### DIFF
--- a/modules/@apostrophecms/home-page/views/page.html
+++ b/modules/@apostrophecms/home-page/views/page.html
@@ -11,7 +11,13 @@
 {% block main %}
   <div class="home">
     <div class="content">
-      {% area data.page, 'main' %}
+      {% area data.page, 'main' with {
+        'two-column': {
+          '@apostrophecms/image': {
+            sizes: '(min-width: 600px) 45vw, (min-width: 1140px) 530px'
+          }
+        }
+      } %}
     </div>
   </div>
 {% endblock %}

--- a/modules/two-column-widget/views/widget.html
+++ b/modules/two-column-widget/views/widget.html
@@ -1,8 +1,8 @@
 <div class="widget-two-column">
   <div class="widget-two-column-one">
-    {% area data.widget, 'one' %}
+    {% area data.widget, 'one' with data.contextOptions %}
   </div>
   <div class="widget-two-column-two">
-    {% area data.widget, 'two' %}
+    {% area data.widget, 'two' with data.contextOptions %}
   </div>
 </div>


### PR DESCRIPTION
Captures contextOptions in two-col and passes them through to the child widgets.

Requires https://github.com/apostrophecms/apostrophe/pull/2754 and https://github.com/apostrophecms/apostrophe/pull/2755