### PR TITLE
only stretch the modal body when we have a footer

### DIFF
--- a/modules/article/index.js
+++ b/modules/article/index.js
@@ -123,15 +123,15 @@ module.exports = {
       });
     });
     const req = self.apos.task.getReq();
-    console.log(req.__('admin req test of req.__ fallback helper'));
-    console.log(req.res.__('admin req test of res.__ fallback helper'));
+    // console.log(req.__('admin req test of req.__ fallback helper'));
+    // console.log(req.res.__('admin req test of res.__ fallback helper'));
   },
   handlers(self) {
     return {
       '@apostrophecms/page:beforeSend': {
         testWarning(req) {
-          console.log(req.__('normal req test of req.__ fallback helper'));
-          console.log(req.res.__('normal res test of req.__ fallback helper'));
+          // console.log(req.__('normal req test of req.__ fallback helper'));
+          // console.log(req.res.__('normal res test of req.__ fallback helper'));
         }
       }
     };


### PR DESCRIPTION
Fixes:
- https://linear.app/apostrophecms/issue/PRO-1948/media-manager-layout-is-disrupted-when-uploading

Original change was made to match the design of the new wizard. Wasn't anticipating this change messing other things up but it did... This ensure's we only stretch it when we add a footer in the body. ( The standard modal footer can't be broken up like the visuals for the wizard. )