### PR TITLE
PRO-4422 add images tables and insert menu

### DIFF
--- a/lib/area.js
+++ b/lib/area.js
@@ -13,8 +13,14 @@ const basicConfig = {
       'blockquote',
       'alignLeft',
       'alignCenter',
-      'alignRight'
+      'alignRight',
+      'codeBlock',
+      'table',
+      'image',
+      'undo',
+      'redo'
     ],
+    insert: [ 'table', 'image' ],
     styles: [
       // you may also use a `class` property with these
       {

--- a/lib/area.js
+++ b/lib/area.js
@@ -117,8 +117,7 @@ const fullConfigExpandedGroups = {
           'alignLeft',
           'alignCenter',
           'alignRight',
-          'image',
-          'table'
+          'image'
         ],
         insert: [ 'table', 'image' ],
         styles: [

--- a/lib/area.js
+++ b/lib/area.js
@@ -15,10 +15,10 @@ const basicConfig = {
       'alignCenter',
       'alignRight',
       'codeBlock',
-      'table',
-      'image',
       'undo',
-      'redo'
+      'redo',
+      'image',
+      'table'
     ],
     insert: [ 'table', 'image' ],
     styles: [
@@ -116,7 +116,9 @@ const fullConfigExpandedGroups = {
           'blockquote',
           'alignLeft',
           'alignCenter',
-          'alignRight'
+          'alignRight',
+          'image',
+          'table'
         ],
         insert: [ 'table', 'image' ],
         styles: [

--- a/lib/area.js
+++ b/lib/area.js
@@ -116,8 +116,7 @@ const fullConfigExpandedGroups = {
           'blockquote',
           'alignLeft',
           'alignCenter',
-          'alignRight',
-          'image'
+          'alignRight'
         ],
         insert: [ 'table', 'image' ],
         styles: [

--- a/lib/area.js
+++ b/lib/area.js
@@ -118,6 +118,7 @@ const fullConfigExpandedGroups = {
           'alignCenter',
           'alignRight'
         ],
+        insert: [ 'table', 'image' ],
         styles: [
           // you may also use a `class` property with these
           {

--- a/lib/area.js
+++ b/lib/area.js
@@ -16,9 +16,7 @@ const basicConfig = {
       'alignRight',
       'codeBlock',
       'undo',
-      'redo',
-      'image',
-      'table'
+      'redo'
     ],
     insert: [ 'table', 'image' ],
     styles: [

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -1,3 +1,5 @@
+const areaConfig = require('../../../lib/area').basicConfig;
+
 module.exports = {
   options: {
     label: 'Home Page',
@@ -10,12 +12,7 @@ module.exports = {
         contextual: true,
         max: 1,
         options: {
-          widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [],
-              styles: []
-            }
-          }
+          widgets: areaConfig
         }
       },
       ctaLinks: {

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -1,4 +1,5 @@
-const areaConfig = require('../../../lib/area').basicConfig;
+const { fullConfig, fullConfigExpandedGroups } = require('../../../lib/area');
+const richTextArea = fullConfig['@apostrophecms/rich-text'];
 
 module.exports = {
   options: {
@@ -12,7 +13,13 @@ module.exports = {
         contextual: true,
         max: 1,
         options: {
-          widgets: areaConfig
+          widgets: {
+            '@apostrophecms/rich-text': {
+              toolbar: richTextArea.toolbar,
+              styles: richTextArea.styles,
+              insert: richTextArea.insert
+            }
+          }
         }
       },
       ctaLinks: {
@@ -29,7 +36,7 @@ module.exports = {
         type: 'area',
         options: {
           expanded: true,
-          groups: require('../../../lib/area').fullConfigExpandedGroups
+          groups: fullConfigExpandedGroups
         }
       }
     },
@@ -38,7 +45,9 @@ module.exports = {
         label: 'Basics',
         fields: [
           'title',
-          'main'
+          'main',
+          'cta',
+          'ctaLinks'
         ]
       }
     }

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -16,19 +16,14 @@ module.exports = {
           widgets: {
             '@apostrophecms/rich-text': {
               toolbar: [
-                'styles',
                 'italic',
                 'strike',
                 'link',
-                'alignLeft',
-                'alignCenter',
-                'alignRight',
-                'table',
-                'image',
                 'undo',
-                'redo'
+                'redo',
+                'image',
+                'table'
               ],
-              styles: richTextArea.styles,
               insert: richTextArea.insert
             }
           }

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -20,9 +20,7 @@ module.exports = {
                 'strike',
                 'link',
                 'undo',
-                'redo',
-                'image',
-                'table'
+                'redo'
               ],
               insert: richTextArea.insert
             }

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -15,7 +15,19 @@ module.exports = {
         options: {
           widgets: {
             '@apostrophecms/rich-text': {
-              toolbar: richTextArea.toolbar,
+              toolbar: [
+                'styles',
+                'italic',
+                'strike',
+                'link',
+                'alignLeft',
+                'alignCenter',
+                'alignRight',
+                'table',
+                'image',
+                'undo',
+                'redo'
+              ],
               styles: richTextArea.styles,
               insert: richTextArea.insert
             }

--- a/modules/@apostrophecms/rich-text-widget/index.js
+++ b/modules/@apostrophecms/rich-text-widget/index.js
@@ -2,6 +2,25 @@ module.exports = {
   options: {
     label: 'Rich Text',
     description: 'Add styled text to your page',
-    previewImage: 'png'
+    previewImage: 'png',
+    className: 'o-widget',
+    imageStyles: [
+      {
+        value: 'image-full',
+        label: 'Full Width'
+      },
+      {
+        value: 'image-center',
+        label: 'Center'
+      },
+      {
+        value: 'image-float-left',
+        label: 'Float Left'
+      },
+      {
+        value: 'image-float-right',
+        label: 'Float Right'
+      }
+    ]
   }
 };

--- a/modules/asset/ui/src/_rich-text.scss
+++ b/modules/asset/ui/src/_rich-text.scss
@@ -1,5 +1,5 @@
 .demo-rte {
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   & > *:first-child,
   & > [contenteditable] > *:first-child {
     margin-top: 0;
@@ -36,7 +36,9 @@
     font-size: 1rem;
   }
 
-  h2, h3, h4 {
+  h2,
+  h3,
+  h4 {
     margin: 30px 0;
     line-height: 1.2em;
   }
@@ -78,8 +80,52 @@
   text-align: center;
 }
 
-.highlight-red { color: $brand-red; }
-.highlight-mustard { color: $brand-mustard; }
-.highlight-purple { color: $brand-purple; }
-.highlight-blue { color: $brand-blue; }
-.highlight-seafoam { color: $brand-seafoam; }
+.highlight-red {
+  color: $brand-red;
+}
+.highlight-mustard {
+  color: $brand-mustard;
+}
+.highlight-purple {
+  color: $brand-purple;
+}
+.highlight-blue {
+  color: $brand-blue;
+}
+.highlight-seafoam {
+  color: $brand-seafoam;
+}
+
+// image alignment stuff
+.image-float-left,
+.image-float-right,
+.image-center,
+.image-full {
+  img {
+    width: 100%;
+  }
+}
+
+.image-float-left,
+.image-float-right,
+.image-center {
+  width: 50%;
+}
+
+.image-float-left {
+  float: left;
+  margin: 0 1em 1em 0;
+}
+
+.image-float-right {
+  float: right;
+  margin: 0 0 1em 1em;
+}
+
+.image-center {
+  margin: auto;
+}
+
+.image-full {
+  width: 100%;
+}

--- a/modules/asset/ui/src/_rich-text.scss
+++ b/modules/asset/ui/src/_rich-text.scss
@@ -127,5 +127,5 @@
 }
 
 .image-full {
-  width: 100%;
+  max-width: 100%;
 }


### PR DESCRIPTION
## Summary
Add tables, images and the insert menu to our public demo [PRO-4422](https://linear.app/apostrophecms/issue/PRO-4422/add-tables-images-and-the-insert-menu-to-our-public-demo)

## What are the specific steps to test this change?
1. `npm run dev`
2. http://localhost:3000/
3. Add content > Rich text
4. Typing '/' brings up the insert menu
5. Inserting a table creates a table
6. Inserting an image creates an image with an option to align the image
7. Image alignment works

## What kind of change does this PR introduce?
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [x] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

**Other information:**
The main area on the homepage was configured to allow only a very stripped down rich-text widget. I don't know if this is intentional or not but I updated the are to use the main widget config.