### PR TITLE
Fix annoying empty rich text not editable only in hero

### DIFF
--- a/modules/asset/ui/src/_hero.scss
+++ b/modules/asset/ui/src/_hero.scss
@@ -12,6 +12,11 @@
     text-align: center;
   }
 
+  // Fix empty rich text not editable
+  .demo-rte > [contenteditable] {
+    width: 100%;
+  }
+
   h2 {
     font-size: 80px;
     color: var(--heading-color);


### PR DESCRIPTION
Exactly what the title says. Emphasis on **annoying** - took hours to identify. 